### PR TITLE
Better management and login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2072,6 +2072,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readline-sync": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
+      "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "knex": "^0.16.3",
     "lodash": "^4.17.11",
     "node-cleanup": "^2.1.2",
+    "readline-sync": "^1.4.9",
     "request-promise": "^4.2.4",
     "sqlite3": "^4.0.4",
     "strftime": "^0.10.0",

--- a/src/actions/adduser.js
+++ b/src/actions/adduser.js
@@ -2,7 +2,7 @@ const Database = require('../libs/database');
 const Users = require('../worker/users');
 var readlineSync = require('readline-sync');
 
-async function run() {
+module.exports = async function(env, options) {
     let app = await require('../libs/bootstrap')('adduser');
 
     app.db = new Database(app.conf.get('database.path', './connections.db'));
@@ -45,7 +45,7 @@ async function run() {
     }
 
     process.exit(0);
-}
+};
 
 async function syncQuestion(question, opts, validator) {
     let input = '';
@@ -62,5 +62,3 @@ async function syncQuestion(question, opts, validator) {
 
     return input;
 }
-
-module.exports = run();

--- a/src/actions/run.js
+++ b/src/actions/run.js
@@ -1,0 +1,41 @@
+const readline = require('readline');
+const { spawn } = require('child_process');
+const nodeCleanup = require('node-cleanup');
+
+module.exports = async function(env, options) {
+    // Start the socket layer first so that it's ready for the worker to connect to
+    await require('../sockets/sockets');
+
+    // The worker should restart itself if it crashes
+    let workerProc;
+    let spawnWorker = () => {
+        let nodeBin = process.argv[0];
+        let nodeArgs = [...process.argv.slice(1), 'worker'];
+        nodeArgs.splice(nodeArgs.indexOf('run'), 1);
+        workerProc = spawn(nodeBin, nodeArgs, {stdio: [process.stdin, process.stdout, process.stderr]});
+        workerProc.on('exit', spawnWorker);
+    };
+
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+    process.stdin.on('keypress', (str, key) => {
+        if (key.ctrl && key.name === 'c') {
+            process.exit();
+            return;
+        }
+
+        if (key.name === 'r' && workerProc) {
+            l('Reloading worker process...');
+            workerProc.kill();
+        }
+    });
+
+    spawnWorker();
+
+    // Make sure the worker process also gets killed when we die
+    nodeCleanup((exitCode, signal) => {
+        if (workerProc) {
+            workerProc.kill();
+        }
+    });
+};

--- a/src/adduser/adduser.js
+++ b/src/adduser/adduser.js
@@ -1,0 +1,61 @@
+const Database = require('../libs/database');
+const Users = require('../worker/users');
+var readlineSync = require('readline-sync');
+
+async function run() {
+    let app = await require('../libs/bootstrap')('adduser');
+
+    app.db = new Database(app.conf.get('database.path', './connections.db'));
+    await app.db.init();
+
+    app.userDb = new Users(app.db);
+
+    // username
+    var username = '';
+    while (true) {
+        username = String(readlineSync.question('Username: ')).trim();
+
+        if (0 < username.length) {
+            // username is ok, break
+            break;
+        }
+    }
+
+    // password
+    var password = '';
+    while (true) {
+        password = String(readlineSync.question('Password: ', {hideEchoBack: true})).trim();
+
+        if (0 < password.length) {
+            // password is ok, break
+            break;
+        }
+    }
+
+    // whether new user is an admin
+    var userIsAdmin = false;
+    var answer = readlineSync.question('Admin account? ', {limit: ['true', 't', 'yes', 'y', '1', 'false', 'f', 'no', 'n', '0']}).toLowerCase()
+    if (answer == 'true' || answer == 't' || answer == 'yes' || answer == 'y' || answer == '1') {
+        userIsAdmin = true;
+    }
+
+    let existingUser = await app.userDb.getUser(username);
+    if (existingUser) {
+        console.log(`User ${username} already exists`);
+        process.exit(1);
+    }
+
+    try {
+        await app.userDb.addUser(username, password);
+        console.log(`Added new user ${username}`);
+        process.exit(0);
+    } catch (err) {
+        l.error('Error adding new user:', err.message);
+        console.log('There was an error adding the new user');
+        process.exit(1);
+    }
+
+    process.exit(0);
+}
+
+module.exports = run();

--- a/src/server.js
+++ b/src/server.js
@@ -4,54 +4,87 @@ const { spawn } = require('child_process');
 const nodeCleanup = require('node-cleanup');
 
 (async function() {
-    commander
-        .version('0.0.1')
-        .option('-c, --config <path>', 'Config file path', './config.ini')
-        .option('--worker', 'Launch a worker')
-        .option('--sockets', 'Launch a socket layer')
-        .parse(process.argv);
-
     // Make the args available globally
     process.args = commander;
 
-    if (commander.sockets) {
-        await require('./sockets/sockets');
-    } else if (commander.worker) {
-        await require('./worker/worker');
-    } else {
-        // Start the socket layer first so that it's ready for the worker to connect to
-        await require('./sockets/sockets');
+    commander
+        .version('0.0.1')
+        .option('-c, --config <path>', 'Config file path', './config.ini');
 
-        // The worker should restart itself if it crashes
-        let workerProc;
-        let spawnWorker = () => {
-            let nodeBin = process.argv[0];
-            let nodeArgs = [...process.argv.slice(1), '--worker'];
-            workerProc = spawn(nodeBin, nodeArgs, {stdio: [process.stdin, process.stdout, process.stderr]});
-            workerProc.on('exit', spawnWorker);
-        };
-
-        readline.emitKeypressEvents(process.stdin);
-        process.stdin.setRawMode(true);
-        process.stdin.on('keypress', (str, key) => {
-            if (key.ctrl && key.name === 'c') {
-                process.exit();
-                return;
-            }
-
-            if (key.name === 'r' && workerProc) {
-                l('Reloading worker process...');
-                workerProc.kill();
-            }
+    commander
+        .command('adduser')
+        .description('Add a user')
+        .action(function(env, options) {
+            console.log('adding a new user');
         });
 
-        spawnWorker();
-
-        // Make sure the worker process also gets killed when we die
-        nodeCleanup((exitCode, signal) => {
-            if (workerProc) {
-                workerProc.kill();
-            }
+    commander
+        .command('sockets')
+        .description('Launch a socket layer')
+        .action(async function(env, options) {
+            await require('./sockets/sockets');
         });
+
+    commander
+        .command('worker')
+        .description('Launch a worker')
+        .action(async function(env, options) {
+            await require('./worker/worker');
+        });
+
+    commander
+        .command('run')
+        .description('Launch everything')
+        .action(async function(env, options) {
+            // Start the socket layer first so that it's ready for the worker to connect to
+            await require('./sockets/sockets');
+    
+            // The worker should restart itself if it crashes
+            let workerProc;
+            let spawnWorker = () => {
+                let nodeBin = process.argv[0];
+                let nodeArgs = [...process.argv.slice(1), 'worker'];
+                nodeArgs.splice(nodeArgs.indexOf('run'), 1);
+                console.log('starting:', nodeBin, nodeArgs);
+                workerProc = spawn(nodeBin, nodeArgs, {stdio: [process.stdin, process.stdout, process.stderr]});
+                workerProc.on('exit', spawnWorker);
+            };
+    
+            readline.emitKeypressEvents(process.stdin);
+            process.stdin.setRawMode(true);
+            process.stdin.on('keypress', (str, key) => {
+                if (key.ctrl && key.name === 'c') {
+                    process.exit();
+                    return;
+                }
+    
+                if (key.name === 'r' && workerProc) {
+                    l('Reloading worker process...');
+                    workerProc.kill();
+                }
+            });
+    
+            spawnWorker();
+    
+            // Make sure the worker process also gets killed when we die
+            nodeCleanup((exitCode, signal) => {
+                if (workerProc) {
+                    workerProc.kill();
+                }
+            });
+        });
+
+    // return help on unknown subcommands
+    commander
+        .on('command:*', function () {
+            console.error('Invalid command: %s\nSee --help for a list of available commands.', commander.args.join(' '));
+            process.exit(1);
+        });
+
+    // run everything by default
+    if (process.argv.length === 2) {
+        process.argv.push('run');
     }
+
+    commander.parse(process.argv);
 })();

--- a/src/server.js
+++ b/src/server.js
@@ -14,8 +14,8 @@ const nodeCleanup = require('node-cleanup');
     commander
         .command('adduser')
         .description('Add a user')
-        .action(function(env, options) {
-            console.log('adding a new user');
+        .action(async function(env, options) {
+            await require('./adduser/adduser');
         });
 
     commander

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -91,7 +91,6 @@ async function maybeProcessRegistration(con) {
         networkName = mu[2] || '';
         password = regState.pass || '';
     } else {
-        console.log('3');
         await con.writeMsg('ERROR', 'Invalid password');
         con.close();
         return false;

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -72,10 +72,10 @@ async function maybeProcessRegistration(con) {
     }
 
     // get bnc username and password
-    var username = '';
-    var networkName = '';
-    var password = '';
-    var network = null;
+    let username = '';
+    let networkName = '';
+    let password = '';
+    let network = null;
 
     let m = regState.pass.match(/([^\/:]+)(?:\/([^:]+))?(?::(.*))?/);
     let mu = m = regState.user.match(/([^\/]+)(?:\/(.+))?/);

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -71,18 +71,31 @@ async function maybeProcessRegistration(con) {
         return;
     }
 
-    // Matching for user/network:pass or user:pass
+    // get bnc username and password
+    var username = '';
+    var networkName = '';
+    var password = '';
+    var network = null;
+
     let m = regState.pass.match(/([^\/:]+)(?:\/([^:]+))?(?::(.*))?/);
-    if (!m) {
+    let mu = m = regState.user.match(/([^\/]+)(?:\/(.+))?/);
+    if (m && regState.pass.includes(':')) {
+        // PASS user/network:pass or user:pass
+        username = m[1] || '';
+        networkName = m[2] || '';
+        password = m[3] || '';
+    } else if (mu && regState.pass) {
+        // PASS pass
+        // USER user/network or user
+        username = mu[1] || '';
+        networkName = mu[2] || '';
+        password = regState.pass || '';
+    } else {
+        console.log('3');
         await con.writeMsg('ERROR', 'Invalid password');
         con.close();
         return false;
     }
-
-    let username = m[1] || '';
-    let networkName = m[2] || '';
-    let password = m[3] || '';
-    let network = null;
 
     let hook = await hooks.emit('auth', {username, networkName, password, client: con, userId: null, network: null, isAdmin: false});
     if (hook.prevent) {

--- a/src/worker/clientcontrol.js
+++ b/src/worker/clientcontrol.js
@@ -319,7 +319,7 @@ commands.ADDUSER = {
         let username = parts[0] || '';
         let password = parts[1] || '';
         if (!username || !password) {
-            con.writeStatus('Usage: adduwer <username> <password>');
+            con.writeStatus('Usage: adduser <username> <password>');
             return false;
         }
 

--- a/src/worker/clientcontrol.js
+++ b/src/worker/clientcontrol.js
@@ -12,6 +12,10 @@ module.exports.run = async function(msg, con) {
     let command = input.substr(0, pos).toUpperCase();
     input = input.substr(pos + 1);
 
+    if (command === '') {
+        command = 'HELP';
+    }
+
     if (typeof commands[command] === 'object') {
         let cmd = commands[command];
         if (cmd.requiresNetworkAuth && !con.state.authNetworkId) {
@@ -32,6 +36,14 @@ module.exports.run = async function(msg, con) {
     } else {
         con.writeStatus(`Invalid command (${command})`);
     }
+};
+
+commands.HELP = {
+    requiresNetworkAuth: false,
+    fn: async function(input, con, msg) {
+        con.writeStatus(`Here are the supported commands:`);
+        con.writeStatus(Object.keys(commands).sort().join(' '));
+    },
 };
 
 commands.HELLO =


### PR DESCRIPTION
Right now the only way to get started with kiwibnc is to manually edit databases. This creates some foundations for better management, and gives users a way to natively setup and start using the bouncer as well.

Main changes:

- `node server.js --worker` is now `node server.js worker`
- `node server.js --sockets` is now `node server.js socket`
- `node server.js adduser` now runs users through a short few questions and sets up a user account appropriately.
- `PRIVMSG *bnc help` now responds with the allowed commands (just sending an empty message to the bnc will do the same thing as well, help users see what they can do with it).
- In addition to `PASS name/net:pass`, we now support `PASS pass` + `USER name/net`, which is an alternate login style that ZNC supports (and is easier to make sense of in most client config screens I reckon).

We're now also using the [readline-sync package](https://www.npmjs.com/package/readline-sync) as it's a really nice, clean way to grab lines from the command line. If we add more extensive CLI management this will be extremely useful.