### PR TITLE
Try to track account and send client a 900 when appropriate

### DIFF
--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -41,6 +41,7 @@ module.exports = class Database {
             caps TEXT,
             buffers TEXT,
             nick TEXT,
+            account TEXT,
             net_registered BOOLEAN,
             auth_user_id INTEGER,
             auth_network_id INTEGER,

--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -155,6 +155,11 @@ class ConnectionIncoming {
             this.writeMsgFrom(upstream.state.serverPrefix, regLine[0], nick, ...regLine[1]);
         });
 
+        let account = upstream.state.account;
+        if (account) {
+            this.writeMsgFrom(upstream.state.serverPrefix, '900', nick, `${nick}!${this.state.username}@bnc`, account, `:You are now logged in as ${account}`);
+        }
+
         this.state.netRegistered = true;
 
         // Dump all our joined channels..

--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -156,8 +156,10 @@ class ConnectionIncoming {
         });
 
         let account = upstream.state.account;
+        let username = this.state.username;
+        let host = this.state.host;
         if (account !== '') {
-            this.writeMsgFrom(upstream.state.serverPrefix, '900', nick, `${nick}!${this.state.username}@bnc`, account, `:You are now logged in as ${account}`);
+            this.writeMsgFrom(upstream.state.serverPrefix, '900', nick, `${nick}!${username}@${host}`, account, `You are now logged in as ${account}`);
         }
 
         this.state.netRegistered = true;

--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -156,7 +156,7 @@ class ConnectionIncoming {
         });
 
         let account = upstream.state.account;
-        if (account) {
+        if (account !== '') {
             this.writeMsgFrom(upstream.state.serverPrefix, '900', nick, `${nick}!${this.state.username}@bnc`, account, `:You are now logged in as ${account}`);
         }
 

--- a/src/worker/connectionstate.js
+++ b/src/worker/connectionstate.js
@@ -34,6 +34,7 @@ class ConnectionState {
         this.caps = [];
         this.buffers = Object.create(null);
         this.nick = 'unknown-user';
+        this.account = '';
         this.username = 'user';
         this.realname = 'BNC user';
         this.password = '';
@@ -76,6 +77,7 @@ class ConnectionState {
             port: this.port,
             tls: this.tls,
             type: this.type,
+            account: this.account,
             connected: this.connected,
             sasl: JSON.stringify(this.sasl),
             server_prefix: this.serverPrefix,
@@ -124,6 +126,7 @@ class ConnectionState {
                 this.addBuffer(rowChans[chanName]);
             }
             this.nick = row.nick;
+            this.account = row.account;
             this.netRegistered = row.net_registered;
             this.authUserId = row.auth_user_id;
             this.authNetworkId = row.auth_network_id;

--- a/src/worker/upstreamcommands.js
+++ b/src/worker/upstreamcommands.js
@@ -177,13 +177,13 @@ commands['900'] = async function(msg, con) {
 
     con.state.account = account;
     con.state.save();
-    return false;
+    return true;
 }
 
 commands['901'] = async function(msg, con) {
     con.state.account = '';
     con.state.save();
-    return false;
+    return true;
 }
 
 commands.PING = async function(msg, con) {

--- a/src/worker/upstreamcommands.js
+++ b/src/worker/upstreamcommands.js
@@ -3,7 +3,7 @@ const hooks = require('./hooks');
 
 let commands = Object.create(null);
 
-module.exports.run = async function run(msg, con) {
+module.exports.run = async function run(msg, con) {   
     let hook = await hooks.emit('message_from_upstream', {client: con, message: msg});
     if (hook.prevent) {
         return;
@@ -25,7 +25,7 @@ commands['CAP'] = async function(msg, con) {
         let offeredCaps = mParam(msg, 2, '').split(' ');
         offeredCaps = storedCaps.concat(offeredCaps);
 
-        if (mParamU(msg, 0, '') === '*') {
+        if (mParamU(msg, 2, '') === '*') {
             // More CAPs to follow so store it and come back later
             await con.state.tempSet('caps_receiving', offeredCaps);
             return false;
@@ -67,7 +67,7 @@ commands['CAP'] = async function(msg, con) {
         let acks = mParam(msg, 2, '').split(' ');
         acks = storedAcks.concat(acks);
 
-        if (mParamU(msg, 0, '') === '*') {
+        if (mParamU(msg, 2, '') === '*') {
             // More ACKs to follow so store it and come back later
             await con.state.tempSet('capack_receiving', acks);
             return false;

--- a/src/worker/upstreamcommands.js
+++ b/src/worker/upstreamcommands.js
@@ -181,7 +181,7 @@ commands['900'] = async function(msg, con) {
 }
 
 commands['901'] = async function(msg, con) {
-    con.state.account = null;
+    con.state.account = '';
     con.state.save();
     return false;
 }

--- a/src/worker/upstreamcommands.js
+++ b/src/worker/upstreamcommands.js
@@ -171,6 +171,21 @@ commands['005'] = async function(msg, con) {
     return false;
 };
 
+// keep track of login/logout to forward lines to new clients
+commands['900'] = async function(msg, con) {
+    let account = msg.params[2];
+
+    con.state.account = account;
+    con.state.save();
+    return false;
+}
+
+commands['901'] = async function(msg, con) {
+    con.state.account = null;
+    con.state.save();
+    return false;
+}
+
 commands.PING = async function(msg, con) {
     con.write('PONG :' + msg.params[0] + '\n');
     return false;


### PR DESCRIPTION
Fixes #4, causes an issue found by bd where Kiwi doesn't do `EXTJWT` properly until it sees a `900`. This isn't tested yet and is missing bits but is along the lines of what should resolve the issue.

Main changes:
- Adds the `account` row to the `connections` table on the main db.
- `RPL_LOGGEDIN (900)` will now be sent to newly-connected clients as part of the welcome burst if upstream is logged into an account.
- `CAP` is now negotiated properly. It used to detect `CAP` continuation lines by seeing if param 0 is `*`, but param 0 is always that. Param 2 is `*` if the line's a continuation line, so changed over both instances of this.