### PR TITLE
Fix auth bug on PASS-only login

### DIFF
--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -78,7 +78,7 @@ async function maybeProcessRegistration(con) {
     let network = null;
 
     let m = regState.pass.match(/([^\/:]+)(?:\/([^:]+))?(?::(.*))?/);
-    let mu = m = regState.user.match(/([^\/]+)(?:\/(.+))?/);
+    let mu = regState.user.match(/([^\/]+)(?:\/(.+))?/);
     if (m && regState.pass.includes(':')) {
         // PASS user/network:pass or user:pass
         username = m[1] || '';


### PR DESCRIPTION
#3 introduced this typo which breaks login using just `PASS`. This fixes that (main) style of login.