### PR TITLE
When adding an admin through `adduser`, actually give them admin privs

### DIFF
--- a/src/actions/adduser.js
+++ b/src/actions/adduser.js
@@ -46,7 +46,7 @@ module.exports = async function(env, options) {
     }
 
     try {
-        await app.userDb.addUser(username, password);
+        await app.userDb.addUser(username, password, userIsAdmin);
         console.log(`Added new user ${username}`);
     } catch (err) {
         l.error('Error adding new user:', err.message);

--- a/src/worker/users.js
+++ b/src/worker/users.js
@@ -93,7 +93,7 @@ class Users {
         return this.db.factories.User.query().where('username', 'LIKE', username).first();
     }
 
-    async addUser(username, password) {
+    async addUser(username, password, isAdmin) {
         if (!Helpers.validUsername(username)) {
             return null;
         }
@@ -102,6 +102,9 @@ class Users {
         user.username = username;
         user.password = password;
         user.created_at = Date.now();
+        if (isAdmin === true) {
+            user.admin = true;
+        }
         await user.save();
 
         return user;


### PR DESCRIPTION
Currently, the admin ask isn't actually hooked up when running the `node src/server.js adduser` command. This hooks it up!