### PR TITLE
Support cap-notify

### DIFF
--- a/src/sockets/socketserver.js
+++ b/src/sockets/socketserver.js
@@ -6,6 +6,7 @@ module.exports = class SocketServer extends EventEmitter {
         super();
         this.queue = queue;
         this.id = conId;
+        this.type = 3;
         this.server = new net.Server({allowHalfOpen: false});
 
         this.bindSocketEvents();

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -185,7 +185,13 @@ commands.CAP = async function(msg, con) {
 
     if (mParamU(msg, 0, '') === 'LS') {
         // Record the version of CAP the client is using
-        await con.state.tempSet('capping', mParamU(msg, 1, '301'));
+        let currentVer = con.state.tempGet('capver') || 301;
+        let newVer = parseInt(mParamU(msg, 1, '301'), 10);
+        if (!isNaN(newVer) && newVer > currentVer) {
+            await con.state.tempSet('capver', newVer);
+        }
+
+        await con.state.tempSet('capping', true);
         con.writeFromBnc('CAP', '*', 'LS', availableCaps.join(' '));
     }
 

--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -115,6 +115,10 @@ class ConnectionIncoming {
         return this.writeMsg(m);
     }
 
+    async supportsCapNotify() {
+        return this.state.caps.includes('cap-notify') || (this.state.tempGet('capver') || 301) > 301;
+    }
+
     async registerLocalClient() {
         let regLines = [
             ['001', this.state.nick, 'Welcome to your BNC'],

--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -115,8 +115,17 @@ class ConnectionIncoming {
         return this.writeMsg(m);
     }
 
-    async supportsCapNotify() {
-        return this.state.caps.includes('cap-notify') || (this.state.tempGet('capver') || 301) > 301;
+    supportsCapNotify() {
+        if (this.state.caps.includes('cap-notify')) {
+            return true;
+        }
+
+        // CAP versions over 301 implicitally support cap-notify
+        if ((this.state.tempGet('capver') || 301) > 301) {
+            return true;
+        }
+
+        return false;
     }
 
     async registerLocalClient() {

--- a/src/worker/hooks.js
+++ b/src/worker/hooks.js
@@ -12,6 +12,7 @@ commandHooks.addBuiltInHooks = function addBuiltInHooks() {
     // Some caps to always request
     commandHooks.on('available_caps', event => {
         event.caps.push('batch');
+        event.caps.push('cap-notify');
     });
 
     // server-time support

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -154,8 +154,8 @@ function listenToQueue(app) {
     });
 }
 
-// Start any listening servers on interfaces specified in the config, or any existing
-// servers that were previously started outside of the config
+// Start any listening servers on interfaces specified in the config if they do not
+// exist as an active connection already
 async function startServers(app) {
     let existingBinds = await app.db.all('SELECT host, port FROM connections WHERE type = ?', [
         ConnectionDict.TYPE_LISTENING
@@ -199,7 +199,6 @@ async function loadConnections(app) {
                 port: row.port,
                 id: row.conid,
             });
-            return;
         }
     });
 }


### PR DESCRIPTION
This PR implements support for `cap-notify` including `CAP NEW` and `CAP DEL` messages. It also requests new capabilities as necessary, assuming that it always needs to re-authenticate with `SASL` if it sees the `sasl` cap come in through `CAP NEW`.