### PR TITLE
echo-message support

### DIFF
--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -240,7 +240,7 @@ commands.NOTICE = async function(msg, con) {
     con.upstream && con.upstream.forEachClient((client) => {
         let m = new Message('NOTICE', msg.params[0], msg.params[1]);
         m.prefix = con.upstream.state.nick;
-        m.from_client = true;
+        m.source = 'client';
         client.writeMsg(m);
     }, con);
 
@@ -259,7 +259,7 @@ commands.PRIVMSG = async function(msg, con) {
     con.upstream && con.upstream.forEachClient((client) => {
         let m = new Message('PRIVMSG', msg.params[0], msg.params[1]);
         m.prefix = con.upstream.state.nick;
-        m.from_client = true;
+        m.source = 'client';
         client.writeMsg(m);
     }, con);
 

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -198,7 +198,7 @@ commands.CAP = async function(msg, con) {
     if (mParamU(msg, 0, '') === 'REQ') {
         let requested = mParam(msg, 1, '').split(' ');
         let matched = requested.filter((cap) => availableCaps.has(cap));
-        con.state.caps = new Set(Array.from(con.state.caps).concat(matched));
+        con.state.caps = new Set([...con.state.caps, ...matched]);
         await con.state.save();
         con.writeFromBnc('CAP', '*', 'ACK', matched.join(' '));
     }

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -176,11 +176,11 @@ async function maybeProcessRegistration(con) {
  */
 
 commands.CAP = async function(msg, con) {
-    let availableCaps = [];
+    let availableCaps = new Set();
     await hooks.emit('available_caps', {client: con, caps: availableCaps});
 
     if (mParamU(msg, 0, '') === 'LIST') {
-        con.writeFromBnc('CAP', '*', 'LIST', con.state.caps.join(' '));
+        con.writeFromBnc('CAP', '*', 'LIST', Array.from(con.state.caps).join(' '));
     }
 
     if (mParamU(msg, 0, '') === 'LS') {
@@ -192,13 +192,13 @@ commands.CAP = async function(msg, con) {
         }
 
         await con.state.tempSet('capping', true);
-        con.writeFromBnc('CAP', '*', 'LS', availableCaps.join(' '));
+        con.writeFromBnc('CAP', '*', 'LS', Array.from(availableCaps).join(' '));
     }
 
     if (mParamU(msg, 0, '') === 'REQ') {
         let requested = mParam(msg, 1, '').split(' ');
-        let matched = requested.filter((cap) => availableCaps.includes(cap));
-        con.state.caps = con.state.caps.concat(matched);
+        let matched = requested.filter((cap) => availableCaps.has(cap));
+        con.state.caps = new Set(Array.from(con.state.caps).concat(matched));
         await con.state.save();
         con.writeFromBnc('CAP', '*', 'ACK', matched.join(' '));
     }

--- a/src/worker/clientcommands.js
+++ b/src/worker/clientcommands.js
@@ -1,4 +1,4 @@
-const { ircLineParser } = require('irc-framework');
+const { ircLineParser, Message } = require('irc-framework');
 const { mParam, mParamU } = require('../libs/helpers');
 const ClientControl = require('./clientcontrol');
 const hooks = require('./hooks');
@@ -238,7 +238,10 @@ commands.USER = async function(msg, con) {
 commands.NOTICE = async function(msg, con) {
     // Send this message to other connected clients
     con.upstream && con.upstream.forEachClient((client) => {
-        client.writeMsgFrom(con.upstream.state.nick, 'NOTICE', msg.params[0], msg.params[1]);
+        let m = new Message('NOTICE', msg.params[0], msg.params[1]);
+        m.prefix = con.upstream.state.nick;
+        m.from_client = true;
+        client.writeMsg(m);
     }, con);
 
     if (con.upstream && con.upstream.state.logging) {
@@ -254,7 +257,10 @@ commands.NOTICE = async function(msg, con) {
 commands.PRIVMSG = async function(msg, con) {
     // Send this message to other connected clients
     con.upstream && con.upstream.forEachClient((client) => {
-        client.writeMsgFrom(con.upstream.state.nick, 'PRIVMSG', msg.params[0], msg.params[1]);
+        let m = new Message('PRIVMSG', msg.params[0], msg.params[1]);
+        m.prefix = con.upstream.state.nick;
+        m.from_client = true;
+        client.writeMsg(m);
     }, con);
 
     // PM to *bnc while logged in

--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -116,7 +116,7 @@ class ConnectionIncoming {
     }
 
     supportsCapNotify() {
-        if (this.state.caps.includes('cap-notify')) {
+        if (this.state.caps.has('cap-notify')) {
             return true;
         }
 
@@ -224,7 +224,7 @@ class ConnectionIncoming {
 
         // If the client supports BOUNCER commands, it will request a buffer list
         // itself and then request messages as needed
-        if (!this.state.caps.includes('bouncer')) {
+        if (!this.state.caps.has('bouncer')) {
             await this.dumpChannels();
         } else {
             // Get the latest NAMEs replies for our joined channels
@@ -273,7 +273,7 @@ class ConnectionIncoming {
                 Date.now() - 3600*1000
             );
 
-            let supportsTime = this.state.caps.includes('server-time');
+            let supportsTime = this.state.caps.has('server-time');
             messages.forEach(async (msg) => {
                 if (!supportsTime) {
                     msg.params[1] = `[${strftime('%H:%M:%S')}] ${msg.params[1]}`;

--- a/src/worker/connectionstate.js
+++ b/src/worker/connectionstate.js
@@ -31,7 +31,7 @@ class ConnectionState {
         this.serverPrefix = 'bnc';
         this.registrationLines = [];
         this.isupports = [];
-        this.caps = [];
+        this.caps = new Set();
         this.buffers = Object.create(null);
         this.nick = 'unknown-user';
         this.account = '';
@@ -85,7 +85,7 @@ class ConnectionState {
             server_prefix: this.serverPrefix,
             registration_lines: JSON.stringify(this.registrationLines),
             isupports: JSON.stringify(this.isupports),
-            caps: JSON.stringify(this.caps),
+            caps: JSON.stringify(Array.from(this.caps)),
             buffers: JSON.stringify(this.buffers),
             nick: this.nick,
             received_motd: this.receivedMotd,
@@ -119,7 +119,7 @@ class ConnectionState {
         if (!row) {
             this.registrationLines = [];
             this.isupports = [];
-            this.caps = [];
+            this.caps = new Set();
             this.buffers = [];
             this.tempData = {};
             this.logging = true;
@@ -133,7 +133,7 @@ class ConnectionState {
             this.serverPrefix = row.server_prefix;
             this.registrationLines = JSON.parse(row.registration_lines);
             this.isupports = JSON.parse(row.isupports);
-            this.caps = JSON.parse(row.caps);
+            this.caps = new Set(JSON.parse(row.caps));
             this.buffers = Object.create(null);
             let rowChans = JSON.parse(row.buffers);
             for (let chanName in rowChans) {

--- a/src/worker/extensions/bouncer/index.js
+++ b/src/worker/extensions/bouncer/index.js
@@ -9,14 +9,14 @@ module.exports.init = async function init(hooks, app) {
         }
 
         upstream.forEachClient(client => {
-            if (client.state.caps.includes('BOUNCER')) {
+            if (client.state.caps.has('BOUNCER')) {
                 client.writeMsg('BOUNCER', 'state', network.name, state);
             }
         });
     };
 
     hooks.on('available_caps', event => {
-        event.caps.push('bouncer');
+        event.caps.add('bouncer');
     });
 
     hooks.on('connection_open', event => {

--- a/src/worker/extensions/bouncer/index.js
+++ b/src/worker/extensions/bouncer/index.js
@@ -9,7 +9,7 @@ module.exports.init = async function init(hooks, app) {
         }
 
         upstream.forEachClient(client => {
-            if (client.state.caps.has('BOUNCER')) {
+            if (client.state.caps.has('bouncer')) {
                 client.writeMsg('BOUNCER', 'state', network.name, state);
             }
         });

--- a/src/worker/extensions/echo-message/index.js
+++ b/src/worker/extensions/echo-message/index.js
@@ -10,12 +10,6 @@ module.exports.init = async function init(hooks) {
     });
     hooks.on('wanted_caps', (event) => {
         event.wantedCaps.add('echo-message');
-        Array.from(event.client.state.linkedIncomingConIds).forEach((linkedId) => {
-            let cCon = event.client.conDict.map.get(linkedId);
-            if(cCon.state.caps.has('echo-message')) {
-                event.wantedCaps.add('echo-message');
-            }
-        })
     });
     hooks.on('message_from_client', (event) => {
         if (!event.client.state.netRegistered) {
@@ -55,9 +49,14 @@ module.exports.init = async function init(hooks) {
         if(!event.client.upstream) {
             return;
         }
-        if((event.message.command === 'PRIVMSG' || event.message.command === 'NOTICE')
-        && (event.client.state.nick === event.message.prefix)) {
-            event.preventDefault();
+        let {client, message} = event;
+        if(message.command === 'PRIVMSG' || message.command === 'NOTICE') {
+            if (!client.state.caps.has('echo-message')
+            && client.state.nick+'!'+client.state.username === message.nick+'!'+message.ident) {
+                event.preventDefault();
+            } else if(client.state.caps.has('echo-message') && !message.tags.msgid) {
+                event.preventDefault();
+            }
         }
     });
 };

--- a/src/worker/extensions/echo-message/index.js
+++ b/src/worker/extensions/echo-message/index.js
@@ -1,0 +1,37 @@
+const IrcMessage = require('irc-framework').Message;
+
+let baseId = 'kiwibnc-'+Date.now();
+let msgId = 0;
+
+module.exports.init = async function init(hooks) {
+    // echo-message support
+    hooks.on('available_caps', event => {
+        event.caps.add('echo-message');
+    });
+    hooks.on('message_from_client', event => {
+        if (!event.client.state.netRegistered) {
+            return;
+        }
+        let upstream = event.client.upstream;
+
+        // If the server doesn't support echo-message we do it ourselves with our own message.
+        if (!upstream.state.caps.has('echo-message')) {
+            let msg = event.message;
+            if(msg.command !== 'PRIVMSG' && msg.command !== 'NOTICE' && msg.command !== 'ACTION') {
+                return;
+            }
+            // Give ID to original message so it is stored correctly
+            msg.tags.msgid = baseId + '-' + msgId++;
+
+            let m = new IrcMessage(msg.command, ...msg.params);
+            m.tags = {...msg.tags};
+            m.nick = upstream.state.nick;
+            m.username = upstream.state.username;
+            m.hostname = upstream.state.host;
+            
+            m.prefix = m.nick+'!'+m.username+'@'+m.hostname;
+
+            event.client.writeMsg(m);
+        }
+    });
+};

--- a/src/worker/extensions/echo-message/index.js
+++ b/src/worker/extensions/echo-message/index.js
@@ -5,15 +5,26 @@ let msgId = 0;
 
 module.exports.init = async function init(hooks) {
     // echo-message support
-    hooks.on('available_caps', event => {
+    hooks.on('available_caps', (event) => {
         event.caps.add('echo-message');
     });
-    hooks.on('message_from_client', event => {
+    hooks.on('wanted_caps', (event) => {
+        event.wantedCaps.add('echo-message');
+        Array.from(event.client.state.linkedIncomingConIds).forEach((linkedId) => {
+            let cCon = event.client.conDict.map.get(linkedId);
+            if(cCon.state.caps.has('echo-message')) {
+                event.wantedCaps.add('echo-message');
+            }
+        })
+    });
+    hooks.on('message_from_client', (event) => {
         if (!event.client.state.netRegistered) {
             return;
         }
         let upstream = event.client.upstream;
-
+        if(!upstream) {
+            return;
+        }
         // If the server doesn't support echo-message we do it ourselves with our own message.
         if (!upstream.state.caps.has('echo-message')) {
             let msg = event.message;
@@ -28,10 +39,25 @@ module.exports.init = async function init(hooks) {
             m.nick = upstream.state.nick;
             m.username = upstream.state.username;
             m.hostname = upstream.state.host;
-            
-            m.prefix = m.nick+'!'+m.username+'@'+m.hostname;
+            m.prefix = m.nick + '!' + m.username + '@' + m.hostname;
 
-            event.client.writeMsg(m);
+            upstream.forEachClient((client) => {
+                // Don't echo back to client that sent if it's not expecting it.
+                if(client === event.client && !event.client.state.caps.has('echo-message')) {
+                    return;
+                }
+                client.writeMsg(m);
+            });
+        }
+    });
+    hooks.on('message_to_client', (event) => {
+        // Disables normal bnc behavior of echoing a message to connected clients
+        if(!event.client.upstream) {
+            return;
+        }
+        if((event.message.command === 'PRIVMSG' || event.message.command === 'NOTICE')
+        && (event.client.state.nick === event.message.prefix)) {
+            event.preventDefault();
         }
     });
 };

--- a/src/worker/extensions/echo-message/index.js
+++ b/src/worker/extensions/echo-message/index.js
@@ -22,7 +22,7 @@ module.exports.init = async function init(hooks) {
         // If the server doesn't support echo-message we do it ourselves with our own message.
         if (!upstream.state.caps.has('echo-message')) {
             let msg = event.message;
-            if(msg.command !== 'PRIVMSG' && msg.command !== 'NOTICE' && msg.command !== 'ACTION') {
+            if(msg.command !== 'PRIVMSG' && msg.command !== 'NOTICE') {
                 return;
             }
             // Give ID to original message so it is stored correctly
@@ -54,8 +54,8 @@ module.exports.init = async function init(hooks) {
             if (!client.state.caps.has('echo-message')
             && client.state.nick+'!'+client.state.username === message.nick+'!'+message.ident) {
                 event.preventDefault();
-            } else if(client.state.caps.has('echo-message') && !message.tags.msgid) {
-                event.preventDefault();
+            } else if(client.state.caps.has('echo-message') && message.from_client) {
+                event.preventDefault(); // Client and server support echo-message and msg came from a client, so ignore it.
             }
         }
     });

--- a/src/worker/extensions/echo-message/index.js
+++ b/src/worker/extensions/echo-message/index.js
@@ -54,7 +54,7 @@ module.exports.init = async function init(hooks) {
             if (!client.state.caps.has('echo-message')
             && client.state.nick+'!'+client.state.username === message.nick+'!'+message.ident) {
                 event.preventDefault();
-            } else if(client.state.caps.has('echo-message') && message.from_client) {
+            } else if(client.state.caps.has('echo-message') && message.source === 'client') {
                 event.preventDefault(); // Client and server support echo-message and msg came from a client, so ignore it.
             }
         }

--- a/src/worker/extensions/echo-message/index.js
+++ b/src/worker/extensions/echo-message/index.js
@@ -22,7 +22,7 @@ module.exports.init = async function init(hooks) {
         // If the server doesn't support echo-message we do it ourselves with our own message.
         if (!upstream.state.caps.has('echo-message')) {
             let msg = event.message;
-            if(msg.command !== 'PRIVMSG' && msg.command !== 'NOTICE') {
+            if(msg.command !== 'PRIVMSG' && msg.command !== 'NOTICE' && msg.command !== 'TAGMSG') {
                 return;
             }
             // Give ID to original message so it is stored correctly
@@ -50,9 +50,9 @@ module.exports.init = async function init(hooks) {
             return;
         }
         let {client, message} = event;
-        if(message.command === 'PRIVMSG' || message.command === 'NOTICE') {
+        if(message.command === 'PRIVMSG' || message.command === 'NOTICE' || message.command === 'TAGMSG') {
             if (!client.state.caps.has('echo-message')
-            && client.state.nick+'!'+client.state.username === message.nick+'!'+message.ident) {
+            && client.upstream.state.nick === message.nick) {
                 event.preventDefault();
             } else if(client.state.caps.has('echo-message') && message.source === 'client') {
                 event.preventDefault(); // Client and server support echo-message and msg came from a client, so ignore it.

--- a/src/worker/hooks.js
+++ b/src/worker/hooks.js
@@ -11,15 +11,15 @@ module.exports = commandHooks;
 commandHooks.addBuiltInHooks = function addBuiltInHooks() {
     // Some caps to always request
     commandHooks.on('available_caps', event => {
-        event.caps.push('batch');
-        event.caps.push('cap-notify');
+        event.caps.add('batch');
+        event.caps.add('cap-notify');
     });
 
     // server-time support
     commandHooks.on('message_to_client', event => {
         let caps = event.client.state.caps;
 
-        if (caps.includes('server-time')) {
+        if (caps.has('server-time')) {
             if (!event.message.tags['time']) {
                 event.message.tags['time'] = isoTime();
             }
@@ -28,37 +28,37 @@ commandHooks.addBuiltInHooks = function addBuiltInHooks() {
         }
     });
     commandHooks.on('available_caps', event => {
-        let caps = event.caps.push('server-time');
+        let caps = event.caps.add('server-time');
     });
 
     // away-notify support
     commandHooks.on('message_to_client', event => {
-        if (!event.client.state.caps.includes('away-notify') && event.message.command === 'AWAY') {
+        if (!event.client.state.caps.has('away-notify') && event.message.command === 'AWAY') {
             event.preventDefault();
         }
     });
     commandHooks.on('available_caps', event => {
-        event.caps.push('away-notify');
+        event.caps.add('away-notify');
     });
 
     // account-notify support
     commandHooks.on('message_to_client', event => {
-        if (!event.client.state.caps.includes('account-notify') && event.message.command === 'ACCOUNT') {
+        if (!event.client.state.caps.has('account-notify') && event.message.command === 'ACCOUNT') {
             event.preventDefault();
         }
     });
     commandHooks.on('available_caps', event => {
-        event.caps.push('account-notify');
+        event.caps.add('account-notify');
     });
 
     // account-tag support
     commandHooks.on('message_to_client', event => {
-        if (!event.client.state.caps.includes('account-tag') && event.message.tags['account']) {
+        if (!event.client.state.caps.has('account-tag') && event.message.tags['account']) {
             delete event.message.tags['account'];
         }
     });
     commandHooks.on('available_caps', event => {
-        event.caps.push('account-tag');
+        event.caps.add('account-tag');
     });
 
     // extended-join support
@@ -69,15 +69,15 @@ commandHooks.addBuiltInHooks = function addBuiltInHooks() {
 
         // Only allow the client to use extended-join if upstream has it
         let upstream = event.client.upstream;
-        if (upstream.state.caps.includes('extended-join')) {
-            event.caps.push('extended-join');
+        if (upstream.state.caps.has('extended-join')) {
+            event.caps.add('extended-join');
         }
     });
     commandHooks.on('message_to_client', event => {
         // :nick!user@host JOIN #channelname * :Real Name
         let caps = event.client.state.caps;
         let m = event.message;
-        if (!caps.includes('extended-join') && m.command === 'JOIN' && m.params.length > 2) {
+        if (!caps.has('extended-join') && m.command === 'JOIN' && m.params.length > 2) {
             // Drop the account name from the params (The * in the above example)
             m.params.splice(1, 1);
         }
@@ -85,7 +85,7 @@ commandHooks.addBuiltInHooks = function addBuiltInHooks() {
 
     // multi-prefix support
     commandHooks.on('available_caps', event => {
-        event.caps.push('multi-prefix');
+        event.caps.add('multi-prefix');
     });
     commandHooks.on('message_to_client', event => {
         let m = event.message;
@@ -100,7 +100,7 @@ commandHooks.addBuiltInHooks = function addBuiltInHooks() {
 
         let clientCaps = event.client.state.caps;
         let upstreamCaps = event.client.upstream.state.caps;
-        if (!clientCaps.includes('multi-prefix') && upstreamCaps.includes('multi-prefix')) {
+        if (!clientCaps.has('multi-prefix') && upstreamCaps.has('multi-prefix')) {
             // Make sure only one prefix is included in the message before sending them to the client
 
             let prefixes = event.client.upstream.state.isupports.find(token => {
@@ -148,13 +148,13 @@ commandHooks.addBuiltInHooks = function addBuiltInHooks() {
 
     // userhost-in-names support
     commandHooks.on('available_caps', event => {
-        event.caps.push('userhost-in-names');
+        event.caps.add('userhost-in-names');
     });
     commandHooks.on('message_to_client', event => {
         // :server.com 353 guest = #tethys :~&@%+aji &@Attila @+alyx +KindOne Argure
         let caps = event.client.state.caps;
         let m = event.message;
-        if (m.command === '353' && !caps.includes('userhost-in-names')) {
+        if (m.command === '353' && !caps.has('userhost-in-names')) {
             let prefixes = event.client.upstream.state.isupports.find(token => {
                 return token.indexOf('PREFIX=') === 0;
             });

--- a/src/worker/upstreamcommands.js
+++ b/src/worker/upstreamcommands.js
@@ -8,7 +8,6 @@ module.exports.run = async function run(msg, con) {
     if (hook.prevent) {
         return;
     }
-    msg.tags.bnc = 1;
     let command = msg.command.toUpperCase();
     if (commands[command]) {
         let ret = await commands[command](msg, con);
@@ -20,7 +19,7 @@ module.exports.run = async function run(msg, con) {
 };
 
 commands['CAP'] = async function(msg, con) {
-    let wantedCaps = [
+    let wantedCaps = new Set([
         'server-time',
         'multi-prefix',
         'away-notify',
@@ -31,8 +30,8 @@ commands['CAP'] = async function(msg, con) {
         'cap-notify',
         'sasl',
         'message-tags',
-        'echo-message'
-    ];
+    ]);
+    await hooks.emit('wanted_caps', {client: con, wantedCaps});
 
     // :irc.example.net CAP * LS :invite-notify ...
     if (mParamU(msg, 1, '') === 'LS') {
@@ -58,7 +57,7 @@ commands['CAP'] = async function(msg, con) {
         // Make a list of CAPs we want to REQ
         let requestingCaps = offeredCaps
             .filter((cap) => (
-                wantedCaps.includes(cap.split('=')[0].toLowerCase())
+                wantedCaps.has(cap.split('=')[0].toLowerCase())
             ))
             .map((cap) => cap.split('=')[0]);
 
@@ -83,7 +82,7 @@ commands['CAP'] = async function(msg, con) {
         //  if a cap's being offered to us via NEW we know we don't have it
         let requestingCaps = offeredCaps
             .filter((cap) => (
-                wantedCaps.includes(cap.split('=')[0].toLowerCase())
+                wantedCaps.has(cap.split('=')[0].toLowerCase())
             ))
             .map((cap) => cap.split('=')[0]);
 

--- a/src/worker/upstreamcommands.js
+++ b/src/worker/upstreamcommands.js
@@ -103,8 +103,8 @@ commands['CAP'] = async function(msg, con) {
         let removedCaps = mParam(msg, 2, '').split(' ');
 
         let caps = con.state.caps || new Set();
-        caps = new Set(Array.from(caps.filter((cap) => !removedCaps.map((rcap) => rcap.toLowerCase())
-            .includes(cap.split('=')[0].toLowerCase()))));
+        caps = new Set(Array.from(caps).filter((cap) => !removedCaps.map((rcap) => rcap.toLowerCase())
+            .includes(cap.split('=')[0].toLowerCase())));
 
         con.state.caps = caps;
         await con.state.save();


### PR DESCRIPTION
This will make the BNC request echo-message support from the server, if the server does not support it then kiwibnc will provide the functionality to clients which request it.

I changed the `caps` from being a `Array` to a `Set` because during my debugging I was seeing the array get larger and larger over time with thousands of duplicate entries, can split that out an PR separately if needed.