### PR TITLE
Add option to skip verifying certificates when connecting to tls servers

### DIFF
--- a/src/dbschemas/20190930110502_add_tlsverify.js
+++ b/src/dbschemas/20190930110502_add_tlsverify.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+    return knex.schema.raw(`
+        ALTER TABLE connections ADD COLUMN tlsverify boolean default 1
+    `).raw(`
+        ALTER TABLE user_networks ADD COLUMN tlsverify boolean default 1
+    `);
+};
+
+exports.down = function(knex) {
+    // sqlite doesn't support removing columns
+};

--- a/src/libs/dataModels/network.js
+++ b/src/libs/dataModels/network.js
@@ -31,6 +31,9 @@ class Network extends DatabaseSavable {
     get tls() { return this.getData('tls'); }
     set tls(newVal) { return this.setData('tls', newVal); }
     
+    get tlsverify() { return this.getData('tlsverify'); }
+    set tlsverify(newVal) { return this.setData('tlsverify', newVal); }
+
     get nick() { return this.getData('nick'); }
     set nick(newVal) { return this.setData('nick', newVal); }
     

--- a/src/sockets/connection.js
+++ b/src/sockets/connection.js
@@ -86,6 +86,7 @@ module.exports = class SocketConnection extends EventEmitter {
             this.sock = tls.connect({
                 socket: this.sock,
                 servername: tlsOpts.servername || undefined,
+                rejectUnauthorized: tlsOpts.tlsverify
             });
 
             bindEvents();
@@ -110,7 +111,7 @@ module.exports = class SocketConnection extends EventEmitter {
         };
 
         sock.connect(connectOpts);
-        this.socketLifecycle(useTls ? { servername: opts.servername } : null);
+        this.socketLifecycle(useTls ? { servername: opts.servername, tlsverify: opts.tlsverify } : null);
     }
 
     close() {

--- a/src/sockets/sockets.js
+++ b/src/sockets/sockets.js
@@ -57,6 +57,7 @@ async function run() {
             bindPort: event.bindPort,
             family: event.family,
             servername: event.servername,
+            tlsverify: event.tlsverify,
         });
     });
 

--- a/src/worker/clientcontrol.js
+++ b/src/worker/clientcontrol.js
@@ -173,6 +173,7 @@ commands.CHANGENETWORK = {
             address: 'host',
             port: {column: 'port', type: 'number'},
             tls: {column: 'tls', type: 'bool'},
+            tlsverify: {column: 'tlsverify', type: 'bool'},
             ssl: {column: 'tls', type: 'bool'},
             secure: {column: 'tls', type: 'bool'},
             nick: 'nick',
@@ -236,7 +237,7 @@ commands.CHANGENETWORK = {
             con.writeStatus(`Updated network`);
         } else {
             con.writeStatus(`Usage: changenetwork server=irc.example.net port=6697 tls=yes`);
-            con.writeStatus(`Available fields: name, server, port, tls, nick, username, realname, password, account, account_password`);
+            con.writeStatus(`Available fields: name, server, port, tls, tlsverify, nick, username, realname, password, account, account_password`);
         }
     },
 };
@@ -259,6 +260,7 @@ commands.ADDNETWORK = {
             address: 'host',
             port: {column: 'port', type: 'number'},
             tls: {column: 'tls', type: 'bool'},
+            tlsverify: {column: 'tlsverify', type: 'bool'},
             ssl: {column: 'tls', type: 'bool'},
             secure: {column: 'tls', type: 'bool'},
             nick: 'nick',
@@ -323,7 +325,7 @@ commands.ADDNETWORK = {
         if (missingFields.length > 0) {
             con.writeStatus('Missing fields: ' + missingFields.join(', '));
             con.writeStatus(`Usage: addnetwork name=example server=irc.example.net port=6697 tls=yes nick=mynick`);
-            con.writeStatus(`Available fields: name, server, port, tls, nick, username, realname, password`);
+            con.writeStatus(`Available fields: name, server, port, tls, tlsverify, nick, username, realname, password`);
             return;
         }
 

--- a/src/worker/connectionoutgoing.js
+++ b/src/worker/connectionoutgoing.js
@@ -47,6 +47,7 @@ class ConnectionOutgoing {
             host: this.state.host,
             port: this.state.port,
             tls: this.state.tls,
+            tlsverify: this.state.tlsverify,
             id: this.id,
             bindAddress: this.state.bindHost || '',
             family: undefined,

--- a/src/worker/connectionstate.js
+++ b/src/worker/connectionstate.js
@@ -42,6 +42,7 @@ class ConnectionState {
         this.host = '';
         this.port = 6667;
         this.tls = false;
+        this.tlsverify = true;
         this.bindHost = '';
         this.type = 0; // 0 = outgoing, 1 = incoming, 2 = server
         this.connected = false;
@@ -81,6 +82,7 @@ class ConnectionState {
             host: this.host,
             port: this.port,
             tls: this.tls,
+            tlsverify: this.tlsverify,
             type: this.type,
             account: this.account,
             connected: this.connected,
@@ -121,6 +123,7 @@ class ConnectionState {
             this.host = net.host;
             this.port = net.port;
             this.tls = !!net.tls;
+            this.tlsverify = !!net.tlsverify;
             this.sasl = { account: net.sasl_account || '', password: net.sasl_pass || '' };
             this.nick = net.nick;
         }
@@ -141,6 +144,7 @@ class ConnectionState {
             this.host = row.host;
             this.port = row.port;
             this.tls = row.tls;
+            this.tlsverify = row.tlsverify;
             this.type = row.type;
             this.sasl = JSON.parse(row.sasl || '{"account":"","password":""}');
             this.connected = row.connected;

--- a/src/worker/extensions/bouncer/index.js
+++ b/src/worker/extensions/bouncer/index.js
@@ -115,6 +115,7 @@ async function handleBouncerCommand(event) {
             parts.push('host=' + net.host);
             parts.push('port=' + net.port);
             parts.push('tls=' + (net.tls ? '1' : '0'));
+            parts.push('tlsverify=' + (net.tlsverify ? '1' : '0'));
             parts.push('host=' + net.host);
 
             let netCon = con.conDict.findUsersOutgoingConnection(con.state.authUserId, net.id);
@@ -275,6 +276,7 @@ async function handleBouncerCommand(event) {
                 host: tags.host || '',
                 port: port,
                 tls: (tags.tls === '1'),
+                tlsverify: (tags.tlsverify === '1'),
                 nick: tags.nick || '',
                 username: tags.user || '',
                 realname: '-',
@@ -325,6 +327,10 @@ async function handleBouncerCommand(event) {
             netUpdates.tls = (tags.tls === '1');
         }
 
+        if (tags.tlsverify) {
+            netUpdates.tlsverify = (tags.tlsverify === '1');
+        }
+
         if (tags.nick) {
             netUpdates.nick = tags.nick;
         }
@@ -359,6 +365,10 @@ async function handleBouncerCommand(event) {
 
                 if (prop === 'tls') {
                     upstream.state.tls = netUpdates.tls;
+                }
+
+                if (prop === 'tls') {
+                    upstream.state.tlsverify = netUpdates.tlsverify;
                 }
 
                 if (prop === 'user') {


### PR DESCRIPTION
Adds a `tlsverify` option, defaulting to true, which when disabled allows connecting to servers with self-signed or expired certificates.