### PR TITLE
Fix NAMES command missing users when splitting to multiple lines

### DIFF
--- a/src/worker/connectionincoming.js
+++ b/src/worker/connectionincoming.js
@@ -333,7 +333,6 @@ class ConnectionIncoming {
             if (len + currentLine.length + 1 + currentName.length > 512) {
                 this.writeMsgFrom(upstream.state.serverPrefix, ...args.concat(currentLine));
                 currentLine = '';
-                continue;
             }
 
             currentLine += currentLine.length > 0 ? ' ' + currentName : currentName;


### PR DESCRIPTION
The continue is making it skip adding the currentName to the next line.

hopefully this will fix #90