### PR TITLE
Report server listen errors to console

### DIFF
--- a/src/sockets/socketserver.js
+++ b/src/sockets/socketserver.js
@@ -111,7 +111,7 @@ module.exports = class SocketServer extends EventEmitter {
             this.queue.sendToWorker('connection.close', {id: this.id, error: withError ? lastError : null});
         });
         this.server.on('error', (err) => {
-            this.queue.sendToWorker('connection.error', {id: this.id, error: err});
+            this.queue.sendToWorker('connection.error', {id: this.id, error: {...err, message: err.message}});
             this.server.close();
         });
         this.server.on('listening', (err) => {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -169,6 +169,9 @@ function listenToQueue(app) {
             await con.onUpstreamConnected();
         }
     });
+    app.queue.on('connection.error', async (event) => {
+        l.error(`Server error ${event.id} ${event.error.message}`);
+    });
     app.queue.on('connection.close', async (event) => {
         if (event.error) {
             l.debug(`Connection ${event.id} closed. Error: ${event.error.code}`);


### PR DESCRIPTION
Currently if there are any errors while listening on sockets they are not reported

this change will show errors like access denied or port in use in the console


note: the `{...err, message: err.message}` is because just passing `err` does not include the message for some reason