### PR TITLE
Better server name matching

### DIFF
--- a/src/worker/connectionstate.js
+++ b/src/worker/connectionstate.js
@@ -394,8 +394,9 @@ class ConnectionState {
     }
 
     getBuffer(name) {
-        if (name.indexOf('.') > -1) {
+        if (name.indexOf('.') > -1 && name.match(/^[a-z0-9_\-.]+$/i)) {
             // Route server messages to the server buffer
+            // Server names only contain alphanumeric and .
             name = '*';
         }
 


### PR DESCRIPTION
Channels with a `.` in the name was getting caught as a server buffer as we route nicks with that character in them to the server buffer (only server names can have that character, not nicks). This caused things like `NAMES` replies to be added to the server buffer instead of the channel.