### PR TITLE
worker.js: change raw sqlite call for clearing linked_con_ids

### DIFF
--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -124,7 +124,7 @@ function listenToQueue(app) {
         await app.db.dbConnections.raw('DELETE FROM connections WHERE type = ?', [ConnectionDict.TYPE_INCOMING]);
 
         // Since there are now no incoming connections, clear all incoming<>outgoing links
-        await app.db.dbConnections.raw('UPDATE connections SET linked_con_ids = "[]"');
+        await app.db.dbConnections.raw('UPDATE connections SET linked_con_ids = ?', '[]');
 
         // If we don't have any connections then we have nothing to clear out. We do
         // need to start our servers again though


### PR DESCRIPTION
After updating to latest knex and better-sqlite3 I got

`SqliteError: UPDATE connections SET linked_con_ids = "[]" - no such column: []`