### PR TITLE
Support nested BNC environment overrides

### DIFF
--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -50,18 +50,46 @@ module.exports = class Config extends EventEmitter {
     }
 
     get(key, def) {
+        let envKey = 'BNC_' + key.toUpperCase().replace(/\./g, '_');
+        let directEnvVal = process.env[envKey];
+        if (typeof directEnvVal !== 'undefined') {
+            return this.parseEnvValue(directEnvVal);
+        }
+
         let val = _.get(this.c, key);
+        if (typeof val === 'undefined') {
+            let envPrefix = 'BNC_' + key.toUpperCase().replace(/\./g, '_') + '_';
+            for (let envName in process.env) {
+                if (!envName.startsWith(envPrefix)) {
+                    continue;
+                }
+
+                val = val || {};
+                let prop = envName.slice(envPrefix.length).toLowerCase();
+                if (prop) {
+                    val[prop] = this.parseEnvValue(process.env[envName]);
+                }
+            }
+        }
+
         if (typeof val === 'object') {
             // Replace any property values if there is an environment var overriding it
             for (let prop in val) {
                 let envVal = process.env['BNC_' + (key + '.' + prop).toUpperCase().replace(/\./g, '_')];
                 if (typeof envVal !== 'undefined') {
-                    // If the value looks to be a JSON structure, parse it
-                    if (envVal[0] === '[' || envVal[0] === '{' || envVal[0] === '"') {
-                        envVal = JSON.parse(envVal);
-                    }
+                    val[prop] = this.parseEnvValue(envVal);
+                }
+            }
 
-                    val[prop] = envVal;
+            let envPrefix = 'BNC_' + key.toUpperCase().replace(/\./g, '_') + '_';
+            for (let envName in process.env) {
+                if (!envName.startsWith(envPrefix)) {
+                    continue;
+                }
+
+                let prop = envName.slice(envPrefix.length).toLowerCase();
+                if (prop && typeof val[prop] === 'undefined') {
+                    val[prop] = this.parseEnvValue(process.env[envName]);
                 }
             }
 
@@ -71,6 +99,15 @@ module.exports = class Config extends EventEmitter {
         }
 
         return def;
+    }
+
+    parseEnvValue(envVal) {
+        // If the value looks to be a JSON structure, parse it
+        if (envVal[0] === '[' || envVal[0] === '{' || envVal[0] === '"') {
+            return JSON.parse(envVal);
+        }
+
+        return envVal;
     }
 
     loadDotFile(dotfile) {

--- a/tests/unit/config.js
+++ b/tests/unit/config.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Config = require('../../src/libs/config');
+
+describe('config environment overrides', () => {
+    const envKeys = [
+        'BNC_DATABASE_CRYPT_KEY',
+        'BNC_DATABASE_USERS',
+        'BNC_DATABASE_TABLE_PREFIX',
+        'BNC_PLUGIN_EXAMPLE_ENDPOINT',
+        'BNC_PLUGIN_EXAMPLE_ENABLED',
+    ];
+    let originalEnv;
+
+    beforeEach(() => {
+        originalEnv = {};
+        envKeys.forEach((key) => {
+            originalEnv[key] = process.env[key];
+            delete process.env[key];
+        });
+    });
+
+    afterEach(() => {
+        envKeys.forEach((key) => {
+            if (typeof originalEnv[key] === 'undefined') {
+                delete process.env[key];
+            } else {
+                process.env[key] = originalEnv[key];
+            }
+        });
+    });
+
+    test('applies nested BNC environment overrides to direct scalar reads', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiwibnc-config-'));
+        const configPath = path.join(tmpDir, 'config.ini');
+        fs.writeFileSync(configPath, [
+            '[database]',
+            'users="./users.db"',
+            'crypt_key="local-crypt-key"',
+            'table_prefix=""',
+            '',
+        ].join('\n'));
+
+        process.env.BNC_DATABASE_CRYPT_KEY = '12345678901234567890123456789012';
+        process.env.BNC_DATABASE_USERS = 'mysql://kiwibnc:secret@db.example:3306/kiwibnc';
+        process.env.BNC_DATABASE_TABLE_PREFIX = 'bnc_';
+
+        const config = new Config(configPath);
+        config.load();
+
+        expect(config.get('database.crypt_key')).toBe('12345678901234567890123456789012');
+        expect(config.get('database').users).toBe('mysql://kiwibnc:secret@db.example:3306/kiwibnc');
+        expect(config.get('database').table_prefix).toBe('bnc_');
+    });
+
+    test('adds nested BNC environment overrides missing from config file', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiwibnc-config-'));
+        const configPath = path.join(tmpDir, 'config.ini');
+        fs.writeFileSync(configPath, [
+            '[database]',
+            'users="./users.db"',
+            'crypt_key="local-crypt-key"',
+            '',
+        ].join('\n'));
+
+        process.env.BNC_DATABASE_TABLE_PREFIX = 'bnc_';
+
+        const config = new Config(configPath);
+        config.load();
+
+        expect(config.get('database').table_prefix).toBe('bnc_');
+    });
+
+    test('allows env-only nested section config', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiwibnc-config-'));
+        const configPath = path.join(tmpDir, 'config.ini');
+        fs.writeFileSync(configPath, [
+            '[webserver]',
+            'port=80',
+            '',
+        ].join('\n'));
+
+        process.env.BNC_PLUGIN_EXAMPLE_ENDPOINT = 'https://example.test/api';
+        process.env.BNC_PLUGIN_EXAMPLE_ENABLED = 'true';
+
+        const config = new Config(configPath);
+        config.load();
+
+        expect(config.get('webserver').port).toBe(80);
+        expect(config.get('plugin_example').endpoint).toBe('https://example.test/api');
+        expect(config.get('plugin_example').enabled).toBe('true');
+    });
+});


### PR DESCRIPTION
## Summary
Adds direct and nested BNC_* environment overrides to Config#get(), including env-only nested sections and shared parsing for JSON-like values.

## Why
This makes container/runtime configuration less dependent on rewriting config files while preserving existing config-file defaults.

## Validation
- npx jest tests/unit/config.js --runInBand
- Covered in Jest validation on branch integration.
