### PR TITLE
Normalize inserted IDs across Knex clients

### DIFF
--- a/src/libs/dataModels/databasesavable.js
+++ b/src/libs/dataModels/databasesavable.js
@@ -56,7 +56,10 @@ class DatabaseSavable {
         }
 
         if (!this.getData('id')) {
-            let id = await this._db.dbUsers(this._table).insert(cols).returning('id');
+            let insertQuery = this._db.dbUsers(this._table).insert(cols);
+            let id = DatabaseSavable.supportsInsertReturning(this._db) ?
+                await insertQuery.returning('id') :
+                await insertQuery;
             // knexjs returns the inserted ID within an array
             id = DatabaseSavable.normalizeInsertedId(id);
             if (id) {
@@ -106,6 +109,15 @@ class DatabaseSavable {
         };
 
         return factory;
+    }
+
+    static supportsInsertReturning(db) {
+        let client = db &&
+            db.dbUsers &&
+            db.dbUsers.client &&
+            db.dbUsers.client.config &&
+            db.dbUsers.client.config.client;
+        return client !== 'mysql' && client !== 'mysql2';
     }
 
     static normalizeInsertedId(id) {

--- a/src/libs/dataModels/databasesavable.js
+++ b/src/libs/dataModels/databasesavable.js
@@ -58,7 +58,7 @@ class DatabaseSavable {
         if (!this.getData('id')) {
             let id = await this._db.dbUsers(this._table).insert(cols).returning('id');
             // knexjs returns the inserted ID within an array
-            id = id[0];
+            id = DatabaseSavable.normalizeInsertedId(id);
             if (id) {
                 this._data.id = { col: 'id', val: id, dirty: false };
             }
@@ -106,6 +106,18 @@ class DatabaseSavable {
         };
 
         return factory;
+    }
+
+    static normalizeInsertedId(id) {
+        if (Array.isArray(id)) {
+            return DatabaseSavable.normalizeInsertedId(id[0]);
+        }
+
+        if (id && typeof id === 'object' && Object.prototype.hasOwnProperty.call(id, 'id')) {
+            return id.id;
+        }
+
+        return id;
     }
 
 }

--- a/tests/unit/users.js
+++ b/tests/unit/users.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const DatabaseSavable = require('../../src/libs/dataModels/databasesavable');
+
+describe('database savable models', () => {
+    test('normalizes inserted ids returned by sqlite and other knex clients', () => {
+        expect(DatabaseSavable.normalizeInsertedId([{ id: 5230 }])).toBe(5230);
+        expect(DatabaseSavable.normalizeInsertedId([5230])).toBe(5230);
+        expect(DatabaseSavable.normalizeInsertedId(5230)).toBe(5230);
+    });
+});

--- a/tests/unit/users.js
+++ b/tests/unit/users.js
@@ -3,9 +3,61 @@
 const DatabaseSavable = require('../../src/libs/dataModels/databasesavable');
 
 describe('database savable models', () => {
+    class TestSavable extends DatabaseSavable {}
+    TestSavable.table = 'users';
+
+    function createInsertDb(client, insertResult, returningResult = [{ id: 777 }]) {
+        const returning = jest.fn().mockResolvedValue(returningResult);
+        const insertQuery = Promise.resolve(insertResult);
+        insertQuery.returning = returning;
+        const insert = jest.fn(() => insertQuery);
+        const dbUsers = jest.fn(() => ({ insert }));
+        dbUsers.client = { config: { client } };
+
+        return {
+            db: { dbUsers },
+            insert,
+            returning,
+        };
+    }
+
     test('normalizes inserted ids returned by sqlite and other knex clients', () => {
         expect(DatabaseSavable.normalizeInsertedId([{ id: 5230 }])).toBe(5230);
         expect(DatabaseSavable.normalizeInsertedId([5230])).toBe(5230);
         expect(DatabaseSavable.normalizeInsertedId(5230)).toBe(5230);
+    });
+
+    test('does not call returning for mysql inserts', async () => {
+        const { db, insert, returning } = createInsertDb('mysql', [5230]);
+        const model = new TestSavable(db);
+
+        model.setData('username', 'testuser');
+        await model.save();
+
+        expect(insert).toHaveBeenCalledWith({ username: 'testuser' });
+        expect(returning).not.toHaveBeenCalled();
+        expect(model.getData('id')).toBe(5230);
+    });
+
+    test('does not call returning for mysql2 inserts', async () => {
+        const { db, returning } = createInsertDb('mysql2', [5230]);
+        const model = new TestSavable(db);
+
+        model.setData('username', 'testuser');
+        await model.save();
+
+        expect(returning).not.toHaveBeenCalled();
+        expect(model.getData('id')).toBe(5230);
+    });
+
+    test('keeps returning for clients that support insert returning ids', async () => {
+        const { db, returning } = createInsertDb('pg', [999], [{ id: 5230 }]);
+        const model = new TestSavable(db);
+
+        model.setData('username', 'testuser');
+        await model.save();
+
+        expect(returning).toHaveBeenCalledWith('id');
+        expect(model.getData('id')).toBe(5230);
     });
 });


### PR DESCRIPTION
## Summary
Normalizes insert IDs returned by different Knex clients and avoids calling .returning('id') for MySQL-compatible clients that do not support it.

## Why
SQLite and SQL drivers return inserted IDs in different shapes. MySQL also emits a warning when .returning() is used even though it has no effect.

## Validation
- npx jest tests/unit/users.js --runInBand
- Covered in full Jest validation on branch integration.
