### PR TITLE
Persist configured network channels

### DIFF
--- a/src/worker/users.js
+++ b/src/worker/users.js
@@ -266,6 +266,7 @@ class Users {
         network.password = netInf.password || '';
         network.sasl_account = netInf.sasl_account || '';
         network.sasl_pass = netInf.sasl_pass || '';
+        network.channels = netInf.channels || '';
 
         await network.save();
         return network;

--- a/tests/unit/users.js
+++ b/tests/unit/users.js
@@ -1,0 +1,51 @@
+'use strict';
+
+jest.mock('bcrypt', () => ({
+    compare: jest.fn(),
+}));
+
+const Users = require('../../src/worker/users');
+
+describe('worker users', () => {
+    let originalConfig;
+
+    beforeEach(() => {
+        originalConfig = global.config;
+        global.config = {
+            get: jest.fn(() => -1),
+        };
+    });
+
+    afterEach(() => {
+        global.config = originalConfig;
+    });
+
+    test('addNetwork persists channels', async () => {
+        const saved = [];
+        const db = {
+            factories: {
+                Network: jest.fn(() => ({
+                    save: jest.fn(function save() {
+                        saved.push(this);
+                    }),
+                })),
+            },
+        };
+        const users = new Users(db);
+
+        const network = await users.addNetwork(42, {
+            name: 'ExampleNet',
+            host: 'irc.example.test',
+            port: 6667,
+            tls: false,
+            nick: 'testuser',
+            username: 'testuser',
+            realname: 'testuser',
+            channels: '#lobby,#help',
+        });
+
+        expect(network.channels).toBe('#lobby,#help');
+        expect(saved).toHaveLength(1);
+        expect(saved[0].channels).toBe('#lobby,#help');
+    });
+});


### PR DESCRIPTION
## Summary
Persists the channels field when Users#addNetwork() creates a network.

## Why
Seeded or API-created networks can provide an initial channel list, but the model did not retain it when saving the network.

## Validation
- npx jest tests/unit/users.js --runInBand
- Covered in full Jest validation on branch integration.
