### PR TITLE
Close SQLite retention cleanup timer

### DIFF
--- a/src/worker/messagestores/sqlite.js
+++ b/src/worker/messagestores/sqlite.js
@@ -147,7 +147,18 @@ class SqliteMessageStore {
 
             runCleanupTask();
             // Run cleanup periodically
-            setInterval(runCleanupTask, this.retentionCleanupInterval * 60 * 1000);
+            this.retentionCleanupTimer = setInterval(runCleanupTask, this.retentionCleanupInterval * 60 * 1000);
+        }
+    }
+
+    close() {
+        if (this.retentionCleanupTimer) {
+            clearInterval(this.retentionCleanupTimer);
+            this.retentionCleanupTimer = null;
+        }
+
+        if (this.db && this.db.open) {
+            this.db.close();
         }
     }
 

--- a/tests/unit/sqlite_messagestore.js
+++ b/tests/unit/sqlite_messagestore.js
@@ -50,8 +50,8 @@ describe('SqliteMessageStore Retention & Cleanup', () => {
     });
 
     afterEach(() => {
-        if (store.db && store.db.open) {
-            store.db.close();
+        if (store) {
+            store.close();
         }
     });
 


### PR DESCRIPTION
## Summary
Stores the SQLite message retention interval handle and adds a close() method that clears the interval before closing the database. Updates the retention tests to call close().

## Why
The retention tests passed but left an interval open, causing Jest to wait after completion.

## Validation
- full Jest validation completed and published ghcr.io/relayos/kiwibnc:sha-6148e47
- node --check src/worker/messagestores/sqlite.js
- node --check tests/unit/sqlite_messagestore.js
