### PR TITLE
Support SQL-backed user database DSNs

### DIFF
--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -1,6 +1,76 @@
 const path = require('path');
 const knex = require('knex');
 
+function decodeConnectionPart(value) {
+    return decodeURIComponent(value.replace(/\+/g, '%20'));
+}
+
+function parseMysqlConnectionString(connectionString) {
+    const scheme = connectionString.startsWith('mariadb://') ? 'mariadb://' : 'mysql://';
+    const withoutScheme = connectionString.slice(scheme.length);
+    const authEnd = withoutScheme.lastIndexOf('@');
+    if (authEnd === -1) {
+        throw new Error('Invalid mysql connection string: missing credentials');
+    }
+
+    const auth = withoutScheme.slice(0, authEnd);
+    const hostPath = withoutScheme.slice(authEnd + 1);
+    const userEnd = auth.indexOf(':');
+    if (userEnd === -1) {
+        throw new Error('Invalid mysql connection string: missing password');
+    }
+
+    const slash = hostPath.indexOf('/');
+    const hostPort = slash === -1 ? hostPath : hostPath.slice(0, slash);
+    const databaseAndQuery = slash === -1 ? '' : hostPath.slice(slash + 1);
+    const queryStart = databaseAndQuery.indexOf('?');
+    const database = queryStart === -1 ?
+        databaseAndQuery :
+        databaseAndQuery.slice(0, queryStart);
+    const query = queryStart === -1 ? '' : databaseAndQuery.slice(queryStart + 1);
+
+    let host = hostPort;
+    let port;
+    if (hostPort.startsWith('[')) {
+        const hostEnd = hostPort.indexOf(']');
+        host = hostEnd === -1 ? hostPort : hostPort.slice(1, hostEnd);
+        if (hostEnd !== -1 && hostPort[hostEnd + 1] === ':') {
+            port = Number(hostPort.slice(hostEnd + 2));
+        }
+    } else {
+        const portStart = hostPort.lastIndexOf(':');
+        if (portStart !== -1) {
+            host = hostPort.slice(0, portStart);
+            port = Number(hostPort.slice(portStart + 1));
+        }
+    }
+
+    const connection = {
+        host: decodeConnectionPart(host),
+        user: decodeConnectionPart(auth.slice(0, userEnd)),
+        password: decodeConnectionPart(auth.slice(userEnd + 1)),
+        database: decodeConnectionPart(database),
+    };
+    if (port) {
+        connection.port = port;
+    }
+
+    const params = new URLSearchParams(query);
+    if (params.has('charset')) {
+        connection.charset = params.get('charset');
+    }
+
+    return connection;
+}
+
+function isMysqlConnectionString(connectionString) {
+    return !!connectionString &&
+        (
+            connectionString.startsWith('mysql://') ||
+            connectionString.startsWith('mariadb://')
+        );
+}
+
 module.exports = class Database {
     constructor(config) {
         let dbConf = config.get('database', {});
@@ -21,7 +91,7 @@ module.exports = class Database {
             connection: null,
             acquireConnectionTimeout: 10000,
         };
-        if (usersConStr.indexOf('postgres://') > -1) {
+        if (usersConStr.startsWith('postgres://')) {
             // postgres://someuser:somepassword@somehost:381/somedatabase
             usersDbCon.client = 'pg';
             usersDbCon.connection = usersConStr;
@@ -29,10 +99,13 @@ module.exports = class Database {
             if (searchPathM) {
                 usersDbCon.searchPath = searchPathM[1].split(',');
             }
-        } else if (usersConStr.indexOf('mysql://') > -1) {
+        } else if (isMysqlConnectionString(usersConStr)) {
             // mysql://user:password@127.0.0.1:3306/database
-            // knex handles this connection string internally
-            usersDbCon = usersConStr;
+            usersDbCon = {
+                client: 'mysql',
+                connection: parseMysqlConnectionString(usersConStr),
+                acquireConnectionTimeout: 10000,
+            };
         } else {
             // No scheme:// part in the connection string, assume it's an sqlite filename
             usersDbCon.client = 'better-sqlite3';

--- a/tests/unit/database.js
+++ b/tests/unit/database.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const path = require('path');
+const Database = require('../../src/libs/database');
+
+function createConfig(database, baseDir = '') {
+    return {
+        get(key, def) {
+            if (key === 'database') {
+                return database;
+            }
+            return def;
+        },
+        relativePath(filePath) {
+            if (filePath[0] === '/') {
+                return filePath;
+            }
+            return path.join(baseDir, filePath);
+        },
+    };
+}
+
+describe('database sql user connections', () => {
+    async function closeDb(db) {
+        await db.dbUsers.destroy();
+        await db.dbConnections.destroy();
+    }
+
+    test('parses mysql user dsn with raw slash password', async () => {
+        const db = new Database(createConfig({
+            users: 'mysql://kiwibnc:raw/pass@db.example:3307/kiwibnc',
+        }));
+
+        const connection = db.dbUsers.client.config.connection;
+        expect(db.dbUsers.client.config.client).toBe('mysql');
+        expect(connection.host).toBe('db.example');
+        expect(connection.port).toBe(3307);
+        expect(connection.user).toBe('kiwibnc');
+        expect(connection.password).toBe('raw/pass');
+        expect(connection.database).toBe('kiwibnc');
+
+        await closeDb(db);
+    });
+
+    test('supports mariadb user dsn', async () => {
+        const db = new Database(createConfig({
+            users: 'mariadb://kiwibnc:secret@db.example:3306/kiwibnc',
+        }));
+
+        const connection = db.dbUsers.client.config.connection;
+        expect(db.dbUsers.client.config.client).toBe('mysql');
+        expect(connection.host).toBe('db.example');
+        expect(connection.port).toBe(3306);
+        expect(connection.user).toBe('kiwibnc');
+        expect(connection.password).toBe('secret');
+        expect(connection.database).toBe('kiwibnc');
+
+        await closeDb(db);
+    });
+
+    test('passes mysql charset query parameter to knex connection', async () => {
+        const db = new Database(createConfig({
+            users: 'mysql://kiwibnc:secret@db.example/kiwibnc?charset=utf8mb4',
+        }));
+
+        const connection = db.dbUsers.client.config.connection;
+        expect(connection.charset).toBe('utf8mb4');
+
+        await closeDb(db);
+    });
+
+    test('treats paths containing mysql-like text as sqlite paths', async () => {
+        const db = new Database(createConfig({
+            users: './archive/mysql://users.db',
+        }, '/tmp/kiwibnc'));
+
+        expect(db.dbUsers.client.config.client).toBe('better-sqlite3');
+        expect(db.dbUsers.client.config.connection.filename)
+            .toBe(path.join('/tmp/kiwibnc', './archive/mysql://users.db'));
+
+        await closeDb(db);
+    });
+});


### PR DESCRIPTION
## Summary
Adds MySQL/MariaDB user database DSN parsing and configures Knex with a structured mysql connection object.

## Why
This allows KiwiBNC user data to live in a SQL database while preserving the existing SQLite default.

## Validation
- npx jest tests/unit/database.js --runInBand
- Covered in full Jest validation on branch integration.
