### PR TITLE
Support user database table prefixes

### DIFF
--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -1,9 +1,24 @@
 const path = require('path');
 const knex = require('knex');
 
+const USER_DB_TABLES = new Set([
+    'connections',
+    'users',
+    'user_networks',
+    'user_tokens',
+]);
+
 module.exports = class Database {
     constructor(config) {
         let dbConf = config.get('database', {});
+        let userTablePrefix = dbConf.table_prefix || '';
+        this.userMigrationTableName = `${userTablePrefix}knex_migrations`;
+        let wrapUserIdentifier = (value, origImpl) => {
+            let prefixedValue = USER_DB_TABLES.has(value) ?
+                `${userTablePrefix}${value}` :
+                value;
+            return origImpl(prefixedValue);
+        };
 
 		this.dbConnections = knex({
 			client: 'better-sqlite3',
@@ -25,6 +40,7 @@ module.exports = class Database {
             // postgres://someuser:somepassword@somehost:381/somedatabase
             usersDbCon.client = 'pg';
             usersDbCon.connection = usersConStr;
+            usersDbCon.wrapIdentifier = wrapUserIdentifier;
             let searchPathM = usersConStr.match(/searchPath=([^&]+)/);
             if (searchPathM) {
                 usersDbCon.searchPath = searchPathM[1].split(',');
@@ -39,6 +55,7 @@ module.exports = class Database {
             usersDbCon.useNullAsDefault = true;
             usersDbCon.connection = { filename: config.relativePath(usersConStr) };
             usersDbCon.pool = { propagateCreateError: false };
+            usersDbCon.wrapIdentifier = wrapUserIdentifier;
         }
 
         this.dbUsers = knex(usersDbCon);
@@ -64,12 +81,21 @@ module.exports = class Database {
         return this.dbUsers.raw(sql, params);
     }
 
-    async init() {
-        await this.dbConnections.migrate.latest({
+    migrateConnections() {
+        return this.dbConnections.migrate.latest({
             directory: path.join(__dirname, '..', 'dbschemas', 'connections'),
         });
-        await this.dbUsers.migrate.latest({
+    }
+
+    migrateUsers() {
+        return this.dbUsers.migrate.latest({
             directory: path.join(__dirname, '..', 'dbschemas', 'users'),
+            tableName: this.userMigrationTableName,
         });
+    }
+
+    async init() {
+        await this.migrateConnections();
+        await this.migrateUsers();
     }
 }

--- a/tests/unit/database.js
+++ b/tests/unit/database.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const path = require('path');
+const Database = require('../../src/libs/database');
+
+function createConfig(database, baseDir = '') {
+    return {
+        get(key, def) {
+            if (key === 'database') {
+                return database;
+            }
+            return def;
+        },
+        relativePath(filePath) {
+            if (filePath[0] === '/') {
+                return filePath;
+            }
+            return path.join(baseDir, filePath);
+        },
+    };
+}
+
+describe('database table prefixes', () => {
+    test('prefixes KiwiBNC user tables when configured', () => {
+        const db = new Database(createConfig({
+            users: 'users.db',
+            table_prefix: 'bnc_',
+        }));
+
+        const selectSql = db.dbUsers('users').select('*').toSQL().sql;
+        const joinSql = db.dbUsers('user_networks')
+            .innerJoin('users', 'users.id', 'user_networks.user_id')
+            .innerJoin('user_tokens', 'user_tokens.user_id', 'user_networks.user_id')
+            .select('user_networks.*', 'users.password as _pass')
+            .toSQL()
+            .sql;
+
+        expect(selectSql).toContain('`bnc_users`');
+        expect(joinSql).toContain('`bnc_user_networks`');
+        expect(joinSql).toContain('`bnc_users`');
+        expect(joinSql).toContain('`bnc_user_tokens`');
+        expect(joinSql).not.toContain('`user_networks`');
+        expect(joinSql).not.toContain('`users`');
+        expect(joinSql).not.toContain('`user_tokens`');
+
+        return Promise.all([
+            db.dbUsers.destroy(),
+            db.dbConnections.destroy(),
+        ]);
+    });
+
+    test('prefixes user migration metadata table in shared databases', async () => {
+        const db = new Database(createConfig({
+            state: 'connections.db',
+            users: 'users.db',
+            table_prefix: 'bnc_',
+        }));
+
+        expect(db.userMigrationTableName).toBe('bnc_knex_migrations');
+
+        await db.dbUsers.destroy();
+        await db.dbConnections.destroy();
+    });
+});


### PR DESCRIPTION
## Summary
Adds optional user database table prefixing through Knex identifier wrapping, including the user DB migration metadata table.

## Why
Shared SQL databases often need application-specific table prefixes to avoid collisions.

## Validation
- npx jest tests/unit/database.js --runInBand
- Covered in full Jest validation on branch integration.
