### PR TITLE
Retire stale SQLite users database after SQL migration

### DIFF
--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -1,9 +1,83 @@
 const path = require('path');
+const fs = require('fs');
 const knex = require('knex');
+
+function isMysqlConnectionString(connectionString) {
+    return !!connectionString &&
+        (
+            connectionString.indexOf('mysql://') > -1 ||
+            connectionString.indexOf('mariadb://') > -1
+        );
+}
+
+function timestampForFilename() {
+    return (new Date()).toISOString()
+        .replace(/[-:]/g, '')
+        .replace(/\.\d{3}Z$/, 'Z');
+}
+
+function nextRetiredPath(filePath) {
+    const basePath = `${filePath}.retired-${timestampForFilename()}`;
+    let retiredPath = `${basePath}.bak`;
+    let counter = 1;
+
+    while (fs.existsSync(retiredPath)) {
+        retiredPath = `${basePath}-${counter}.bak`;
+        counter++;
+    }
+
+    return retiredPath;
+}
+
+function logRetiredUsersDb(sourcePath, retiredPath) {
+    const msg = `Retired stale SQLite users database ${sourcePath} to ${retiredPath} because database.users is configured for MySQL/MariaDB`;
+    if (global.l && global.l.warn) {
+        global.l.warn(msg);
+    } else {
+        console.warn(msg);
+    }
+}
+
+function configuredSqliteUsersPath(config, configuredUsersConStr, hasConfiguredDatabase) {
+    if (!hasConfiguredDatabase) {
+        return null;
+    }
+
+    const usersConStr = configuredUsersConStr || 'users.db';
+    if (usersConStr.startsWith('postgres://') ||
+        isMysqlConnectionString(usersConStr)) {
+        return null;
+    }
+
+    return config.relativePath(usersConStr);
+}
+
+function archiveStaleUsersDb(usersDbPath) {
+    if (!usersDbPath) {
+        return;
+    }
+
+    if (!fs.existsSync(usersDbPath)) {
+        return;
+    }
+
+    if (!fs.statSync(usersDbPath).isFile()) {
+        return;
+    }
+
+    const retiredPath = nextRetiredPath(usersDbPath);
+    fs.renameSync(usersDbPath, retiredPath);
+    logRetiredUsersDb(usersDbPath, retiredPath);
+}
 
 module.exports = class Database {
     constructor(config) {
+        let hasConfiguredDatabase = !!(config.c && config.c.database);
+        let configuredUsersConStr = config.c && config.c.database ?
+            config.c.database.users :
+            undefined;
         let dbConf = config.get('database', {});
+        this.staleUsersDbPath = null;
 
 		this.dbConnections = knex({
 			client: 'better-sqlite3',
@@ -21,7 +95,7 @@ module.exports = class Database {
             connection: null,
             acquireConnectionTimeout: 10000,
         };
-        if (usersConStr.indexOf('postgres://') > -1) {
+        if (usersConStr.startsWith('postgres://')) {
             // postgres://someuser:somepassword@somehost:381/somedatabase
             usersDbCon.client = 'pg';
             usersDbCon.connection = usersConStr;
@@ -29,7 +103,8 @@ module.exports = class Database {
             if (searchPathM) {
                 usersDbCon.searchPath = searchPathM[1].split(',');
             }
-        } else if (usersConStr.indexOf('mysql://') > -1) {
+        } else if (isMysqlConnectionString(usersConStr)) {
+            this.staleUsersDbPath = configuredSqliteUsersPath(config, configuredUsersConStr, hasConfiguredDatabase);
             // mysql://user:password@127.0.0.1:3306/database
             // knex handles this connection string internally
             usersDbCon = usersConStr;
@@ -64,12 +139,21 @@ module.exports = class Database {
         return this.dbUsers.raw(sql, params);
     }
 
-    async init() {
-        await this.dbConnections.migrate.latest({
+    migrateConnections() {
+        return this.dbConnections.migrate.latest({
             directory: path.join(__dirname, '..', 'dbschemas', 'connections'),
         });
-        await this.dbUsers.migrate.latest({
+    }
+
+    migrateUsers() {
+        return this.dbUsers.migrate.latest({
             directory: path.join(__dirname, '..', 'dbschemas', 'users'),
         });
+    }
+
+    async init() {
+        await this.migrateConnections();
+        await this.migrateUsers();
+        archiveStaleUsersDb(this.staleUsersDbPath);
     }
 }

--- a/tests/unit/database.js
+++ b/tests/unit/database.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Database = require('../../src/libs/database');
+
+function createConfig(database, baseDir = '', configuredDatabase = undefined) {
+    const config = {
+        get(key, def) {
+            if (key === 'database') {
+                return database;
+            }
+            return def;
+        },
+        relativePath(filePath) {
+            if (filePath[0] === '/') {
+                return filePath;
+            }
+            return path.join(baseDir, filePath);
+        },
+    };
+    if (typeof configuredDatabase !== 'undefined') {
+        config.c = { database: configuredDatabase };
+    }
+    return config;
+}
+
+describe('database stale sqlite users retirement', () => {
+    let tmpDirs = [];
+    let warnSpy;
+
+    beforeEach(() => {
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+
+        tmpDirs.forEach((tmpDir) => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+        tmpDirs = [];
+    });
+
+    function makeTmpDir() {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiwibnc-db-'));
+        tmpDirs.push(tmpDir);
+        return tmpDir;
+    }
+
+    async function closeDb(db) {
+        await db.dbUsers.destroy();
+        await db.dbConnections.destroy();
+    }
+
+    function retiredFiles(tmpDir, filename = 'users.db') {
+        return fs.readdirSync(tmpDir)
+            .filter((entry) => entry.startsWith(`${filename}.retired-`) && entry.endsWith('.bak'));
+    }
+
+    async function runSuccessfulMigrations(db) {
+        db.migrateConnections = jest.fn().mockResolvedValue([]);
+        db.migrateUsers = jest.fn().mockResolvedValue([]);
+        await db.init();
+    }
+
+    test('archives stale users.db after effective mysql config succeeds', async () => {
+        const tmpDir = makeTmpDir();
+        const usersDb = path.join(tmpDir, 'users.db');
+        fs.writeFileSync(usersDb, 'stale user data');
+
+        const db = new Database(createConfig(
+            { users: 'mysql://kiwibnc:secret@db.example:3306/kiwibnc' },
+            tmpDir,
+            { users: './users.db' }
+        ));
+        await runSuccessfulMigrations(db);
+        await closeDb(db);
+
+        const archived = retiredFiles(tmpDir);
+        expect(fs.existsSync(usersDb)).toBe(false);
+        expect(archived).toHaveLength(1);
+        expect(fs.readFileSync(path.join(tmpDir, archived[0]), 'utf8')).toBe('stale user data');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retired stale SQLite users database'));
+    });
+
+    test('does not archive stale users.db before mysql migrations succeed', async () => {
+        const tmpDir = makeTmpDir();
+        const usersDb = path.join(tmpDir, 'users.db');
+        fs.writeFileSync(usersDb, 'must survive failed mysql startup');
+
+        const db = new Database(createConfig(
+            { users: 'mysql://kiwibnc:secret@db.example:3306/kiwibnc' },
+            tmpDir,
+            { users: './users.db' }
+        ));
+        db.migrateConnections = jest.fn().mockResolvedValue([]);
+        db.migrateUsers = jest.fn().mockRejectedValue(new Error('mysql unavailable'));
+
+        await expect(db.init()).rejects.toThrow('mysql unavailable');
+        await closeDb(db);
+
+        expect(fs.existsSync(usersDb)).toBe(true);
+        expect(fs.readFileSync(usersDb, 'utf8')).toBe('must survive failed mysql startup');
+        expect(retiredFiles(tmpDir)).toHaveLength(0);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('archives configured non-default sqlite users path after effective mysql config succeeds', async () => {
+        const tmpDir = makeTmpDir();
+        const defaultUsersDb = path.join(tmpDir, 'users.db');
+        const configuredUsersDb = path.join(tmpDir, 'staging-users.db');
+        fs.writeFileSync(defaultUsersDb, 'unrelated default sqlite file');
+        fs.writeFileSync(configuredUsersDb, 'configured sqlite user data');
+
+        const db = new Database(createConfig(
+            { users: 'mysql://kiwibnc:secret@db.example:3306/kiwibnc' },
+            tmpDir,
+            { users: './staging-users.db' }
+        ));
+        await runSuccessfulMigrations(db);
+        await closeDb(db);
+
+        const archived = retiredFiles(tmpDir, 'staging-users.db');
+        expect(fs.existsSync(defaultUsersDb)).toBe(true);
+        expect(fs.readFileSync(defaultUsersDb, 'utf8')).toBe('unrelated default sqlite file');
+        expect(fs.existsSync(configuredUsersDb)).toBe(false);
+        expect(archived).toHaveLength(1);
+        expect(fs.readFileSync(path.join(tmpDir, archived[0]), 'utf8')).toBe('configured sqlite user data');
+    });
+
+    test('does not archive users.db for direct mysql config without prior sqlite path', async () => {
+        const tmpDir = makeTmpDir();
+        const usersDb = path.join(tmpDir, 'users.db');
+        fs.writeFileSync(usersDb, 'stale user data');
+
+        const db = new Database(createConfig({
+            users: 'mysql://kiwibnc:secret@db.example:3306/kiwibnc',
+        }, tmpDir));
+        await runSuccessfulMigrations(db);
+        await closeDb(db);
+
+        expect(fs.existsSync(usersDb)).toBe(true);
+        expect(retiredFiles(tmpDir)).toHaveLength(0);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('leaves users.db untouched when users database is sqlite', async () => {
+        const tmpDir = makeTmpDir();
+        const usersDb = path.join(tmpDir, 'users.db');
+        fs.writeFileSync(usersDb, 'active sqlite user data');
+
+        const db = new Database(createConfig({
+            users: './users.db',
+        }, tmpDir));
+        await runSuccessfulMigrations(db);
+        await closeDb(db);
+
+        expect(fs.existsSync(usersDb)).toBe(true);
+        expect(fs.readFileSync(usersDb, 'utf8')).toBe('active sqlite user data');
+        expect(retiredFiles(tmpDir)).toHaveLength(0);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
Archives a previously configured SQLite users database only after effective MySQL/MariaDB user database migrations succeed.

## Why
When deployments move from SQLite users.db to a SQL-backed user database, leaving the old users.db in place can be misleading. This preserves the file as a timestamped backup after the SQL path is confirmed usable.

## Validation
- npx jest tests/unit/database.js --runInBand
- Covered in full Jest validation on branch integration.
