### PR TITLE
Prefer custom readable message stores

### DIFF
--- a/src/worker/messagestores/index.js
+++ b/src/worker/messagestores/index.js
@@ -28,7 +28,7 @@ class MessageStores {
     }
 
     async getMessagesFromMsgId(...args) {
-        let readable = this.stores.find(s => s.supportsRead);
+        let readable = this.readableStore();
         if (!readable) {
             return [];
         }
@@ -37,7 +37,7 @@ class MessageStores {
     }
 
     async getMessagesFromTime(...args) {
-        let readable = this.stores.find(s => s.supportsRead);
+        let readable = this.readableStore();
         if (!readable) {
             return [];
         }
@@ -46,7 +46,7 @@ class MessageStores {
     }
 
     async getMessagesBeforeMsgId(...args) {
-        let readable = this.stores.find(s => s.supportsRead);
+        let readable = this.readableStore();
         if (!readable) {
             return [];
         }
@@ -55,7 +55,7 @@ class MessageStores {
     }
 
     async getMessagesBeforeTime(...args) {
-        let readable = this.stores.find(s => s.supportsRead);
+        let readable = this.readableStore();
         if (!readable) {
             return [];
         }
@@ -64,7 +64,7 @@ class MessageStores {
     }
 
     async getMessagesBetween(...args) {
-        let readable = this.stores.find(s => s.supportsRead);
+        let readable = this.readableStore();
         if (!readable) {
             return [];
         }
@@ -76,6 +76,10 @@ class MessageStores {
         this.stores.filter(s => s.supportsWrite).forEach(async store => {
             await store.storeMessage(...args);
         });
+    }
+
+    readableStore() {
+        return this.stores.slice().reverse().find(s => s.supportsRead);
     }
 }
 

--- a/tests/unit/messagestores.js
+++ b/tests/unit/messagestores.js
@@ -1,0 +1,52 @@
+jest.mock('../../src/worker/messagestores/sqlite', () => jest.fn().mockImplementation(() => ({
+    supportsRead: true,
+    supportsWrite: true,
+    init: jest.fn(async () => {}),
+    getMessagesBetween: jest.fn(async () => ['sqlite']),
+    storeMessage: jest.fn(async () => {}),
+})));
+
+jest.mock('../../src/worker/messagestores/flatfile', () => jest.fn().mockImplementation(() => ({
+    supportsRead: false,
+    supportsWrite: true,
+    init: jest.fn(async () => {}),
+    storeMessage: jest.fn(async () => {}),
+})));
+
+jest.mock('/virtual/custom-message-store.js', () => jest.fn().mockImplementation(() => ({
+    supportsRead: true,
+    supportsWrite: true,
+    init: jest.fn(async () => {}),
+    getMessagesBetween: jest.fn(async () => ['custom']),
+    storeMessage: jest.fn(async () => {}),
+})), { virtual: true });
+
+const MessageStores = require('../../src/worker/messagestores/');
+
+describe('MessageStores', () => {
+    function buildConfig() {
+        return {
+            get: jest.fn((key) => {
+                if (key === 'logging.database') {
+                    return './messages.db';
+                }
+                if (key === 'logging.files') {
+                    return '';
+                }
+                if (key === 'logging.custom') {
+                    return '/virtual/custom-message-store.js';
+                }
+                return '';
+            }),
+            relativePath: jest.fn((path) => path),
+        };
+    }
+
+    test('uses custom readable message store before sqlite for history reads', async () => {
+        const stores = new MessageStores(buildConfig());
+
+        await stores.init();
+
+        await expect(stores.getMessagesBetween(1, 2, '#test', {}, {}, 10)).resolves.toEqual(['custom']);
+    });
+});


### PR DESCRIPTION
## Summary

When both `logging.database` and `logging.custom` are configured, KiwiBNC currently writes to every writable message store but reads from the first readable store. Because the SQLite store is initialized before a custom store, a custom readable store cannot be authoritative for history reads.

This changes read selection to prefer the last configured readable store while preserving the existing write fanout behavior.

## Validation

- `NODE_PATH=.../kiwibnc-relayos/node_modules .../kiwibnc-relayos/node_modules/.bin/jest tests/unit/messagestores.js --runInBand`
- `NODE_PATH=.../kiwibnc-relayos/node_modules .../kiwibnc-relayos/node_modules/.bin/jest tests/unit/messagestores.js tests/unit/socketserver.js tests/unit/helpers.js --runInBand`

Note: local dependency installation in this worktree is blocked by the current `better-sqlite3` native binding under Node 22, so these checks used an existing dependency tree from a clean sibling checkout.
