### PR TITLE
Fix user token auth lookup await

### DIFF
--- a/src/worker/users.js
+++ b/src/worker/users.js
@@ -97,7 +97,7 @@ class Users {
     }
 
     async authUserToken(token, userHost) {
-        let user = this.db.dbUsers('users')
+        let user = await this.db.dbUsers('users')
             .innerJoin('user_tokens', 'users.id', 'user_tokens.user_id')
             .where('user_tokens.token', token)
             .where((q) => {

--- a/tests/unit/users.js
+++ b/tests/unit/users.js
@@ -1,0 +1,33 @@
+'use strict';
+
+jest.mock('bcrypt', () => ({
+    compare: jest.fn(),
+}));
+
+const Users = require('../../src/worker/users');
+
+describe('worker/users.js', () => {
+    it('awaits authUserToken lookup before updating token access metadata', async () => {
+        const row = { id: 42, username: 'testuser' };
+        const query = {
+            innerJoin: jest.fn(function innerJoin() { return this; }),
+            where: jest.fn(function where() { return this; }),
+            first: jest.fn(() => Promise.resolve(row)),
+        };
+        const db = {
+            dbUsers: jest.fn(() => query),
+            factories: {
+                User: {
+                    fromDbResult: jest.fn((result) => result),
+                },
+            },
+        };
+        const users = new Users(db);
+        users.updateUserTokenAccess = jest.fn(() => Promise.resolve(1));
+
+        const user = await users.authUserToken('__t1token', '127.0.0.1');
+
+        expect(user).toEqual(row);
+        expect(users.updateUserTokenAccess).toHaveBeenCalledWith(42, '__t1token', '127.0.0.1');
+    });
+});


### PR DESCRIPTION
## Summary\n- await the user-token lookup before checking the returned user\n- add a focused regression test for updating token access metadata with the resolved user id\n\n## Why\nWithout the await, authUserToken() treats the pending Promise as truthy and calls updateUserTokenAccess() with an undefined user id. HTTP bearer-token paths can then fail while compiling the token access update query.\n\n## Test\n- ./node_modules/.bin/jest tests/unit/users.js --runInBand\n- node -c src/worker/users.js